### PR TITLE
BRIP-0002 [DRAFT]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,3 +14,6 @@ rustflags = [
     # in line with Linux (whereas default for Windows is 1MB)
     "-Clink-arg=/STACK:10000000",
 ]
+
+[net]
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,8 +137,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,8 +151,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -235,8 +232,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -277,8 +273,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -316,11 +311,11 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "http",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -330,8 +325,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -356,8 +350,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -428,8 +421,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -471,8 +463,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -514,8 +505,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -542,8 +532,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -555,8 +544,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebdc864f573645c5288370c208912b85b5cacc8025b700c50c2b74d06ab9830"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -567,8 +555,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -579,8 +566,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -590,8 +576,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241aba7808bddc3ad1c6228e296a831f326f89118b1017012090709782a13334"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -608,8 +593,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -618,8 +602,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -639,8 +622,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -651,7 +633,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -660,8 +642,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bd1c5d7b9f3f1caeeaa1c082aa28ba7ce2d67127b12b2a9b462712c8f6e1c5"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -675,8 +656,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -689,8 +669,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -701,8 +680,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -713,8 +691,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -728,8 +705,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -816,8 +792,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -839,8 +814,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -854,8 +828,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -874,8 +847,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+source = "git+https://github.com/rezbera/alloy?branch=BRIP-0002#838df0a5c15e722053210b824b3d3f993ce4e9ed"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -12149,9 +12121,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
 dependencies = [
  "async-compression",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -701,33 +701,33 @@ walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
 [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-consensus = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-contract = { git = "https://github.com/rezbera/alloy", branch = "BRIP-0002" }
+alloy-eips = { git = "https://github.com/rezbera/alloy", branch = "BRIP-0002" }
+alloy-genesis = { git = "https://github.com/rezbera/alloy", branch = "BRIP-0002" }
+alloy-json-rpc = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-network = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-network-primitives = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-provider = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-pubsub = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-client = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-admin = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-anvil = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-beacon = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-debug = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-engine = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-eth = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-mev = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-trace = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-rpc-types-txpool = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-serde = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-signer = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-signer-local = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-transport = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-transport-http = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-transport-ipc = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-transport-ws = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
 
 # alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "main" }
 # alloy-op-evm = { git = "https://github.com/alloy-rs/evm", branch = "main" }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -735,6 +735,7 @@ impl From<Genesis> for ChainSpec {
             paris_block_and_final_difficulty,
             deposit_contract,
             blob_params,
+            // TODO: Change to Variable to allow for hard fork
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::berachain()),
             ..Default::default()
         }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -735,6 +735,7 @@ impl From<Genesis> for ChainSpec {
             paris_block_and_final_difficulty,
             deposit_contract,
             blob_params,
+            base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::berachain()),
             ..Default::default()
         }
     }


### PR DESCRIPTION
To run the PoC of BIP-0002 with minimum base fee:

1. Clone the repo
2. run `cargo build --release`
3. Add `./target/release/reth` to your path
4. Run `make start` in BeaconKit. 
5. Run `make start-reth-local` after adding this to the `testing.mk` file
```sh
## Start an ephemeral `reth` node using the local `reth` binary (no Docker)
start-reth-local:
	$(call ask_reset_dir_func, $(ETH_DATA_DIR))
	@# Launch reth directly, mirroring the flags from the Docker invocation
	reth node \
		--chain $(ETH_GENESIS_PATH) \
		--http \
		--http.addr "0.0.0.0" \
		--http.port 8545 \
		--http.api eth,net \
		--authrpc.addr "0.0.0.0" \
		--authrpc.jwtsecret $(JWT_PATH) \
		--datadir $(ETH_DATA_DIR) \
		--ipcpath $(IPC_PATH) \
		--engine.persistence-threshold 0 \
		--engine.memory-block-buffer-target 0
```

6. Run `cast base-fee`
> 10000000000