### PR TITLE
refactor: enforced with_limits demo

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -28,7 +28,7 @@ use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_ethereum_primitives::{Block, EthPrimitives, TransactionSigned};
 use reth_evm::{
     eth::NextEvmEnvAttributes, precompiles::PrecompilesMap, ConfigureEvm, EvmEnv, EvmFactory,
-    NextBlockEnvAttributes, TransactionEnv,
+    EvmLimitParams, NextBlockEnvAttributes, TransactionEnv,
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use revm::{context::BlockEnv, primitives::hardfork::SpecId};
@@ -154,17 +154,20 @@ where
         &self.block_assembler
     }
 
-    fn evm_env(&self, header: &Header) -> Result<EvmEnv<SpecId>, Self::Error> {
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.chain_spec().evm_limit_params_at_timestamp(timestamp)
+    }
+
+    fn evm_env_without_limits(&self, header: &Header) -> Result<EvmEnv<SpecId>, Self::Error> {
         Ok(EvmEnv::for_eth_block(
             header,
             self.chain_spec(),
             self.chain_spec().chain().id(),
             self.chain_spec().blob_params_at_timestamp(header.timestamp),
-        )
-        .with_limits(self.chain_spec().evm_limit_params_at_timestamp(header.timestamp)))
+        ))
     }
 
-    fn next_evm_env(
+    fn next_evm_env_without_limits(
         &self,
         parent: &Header,
         attributes: &NextBlockEnvAttributes,
@@ -181,8 +184,7 @@ where
             self.chain_spec(),
             self.chain_spec().chain().id(),
             self.chain_spec().blob_params_at_timestamp(attributes.timestamp),
-        )
-        .with_limits(self.chain_spec().evm_limit_params_at_timestamp(attributes.timestamp)))
+        ))
     }
 
     fn context_for_block<'a>(
@@ -273,8 +275,7 @@ where
             blob_excess_gas_and_price,
         };
 
-        Ok(EvmEnv { cfg_env, block_env }
-            .with_limits(self.chain_spec().evm_limit_params_at_timestamp(timestamp)))
+        Ok(EvmEnv { cfg_env, block_env }.with_limits(self.evm_limit_params_at_timestamp(timestamp)))
     }
 
     fn context_for_payload<'a>(

--- a/crates/ethereum/evm/src/test_utils.rs
+++ b/crates/ethereum/evm/src/test_utils.rs
@@ -13,7 +13,7 @@ use reth_evm::{
     },
     eth::{EthBlockExecutionCtx, EthEvmContext, EthTxResult},
     ConfigureEngineEvm, ConfigureEvm, Database, EthEvm, EthEvmFactory, Evm, EvmEnvFor, EvmFactory,
-    ExecutableTxIterator, ExecutionCtxFor, RecoveredTx,
+    EvmLimitParams, ExecutableTxIterator, ExecutionCtxFor, RecoveredTx,
 };
 use reth_execution_types::{BlockExecutionResult, ExecutionOutcome};
 use reth_primitives_traits::{BlockTy, SealedBlock, SealedHeader};
@@ -172,16 +172,20 @@ impl ConfigureEvm for MockEvmConfig {
         self.inner.block_assembler()
     }
 
-    fn evm_env(&self, header: &Header) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.inner.evm_env(header)
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.inner.evm_limit_params_at_timestamp(timestamp)
     }
 
-    fn next_evm_env(
+    fn evm_env_without_limits(&self, header: &Header) -> Result<EvmEnvFor<Self>, Self::Error> {
+        self.inner.evm_env_without_limits(header)
+    }
+
+    fn next_evm_env_without_limits(
         &self,
         parent: &Header,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.inner.next_evm_env(parent, attributes)
+        self.inner.next_evm_env_without_limits(parent, attributes)
     }
 
     fn context_for_block<'a>(

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -58,8 +58,25 @@ pub mod test_utils;
 
 pub use alloy_evm::{
     block::{state_changes, system_calls, OnStateHook},
-    *,
+    EvmLimitParams, *,
 };
+
+use alloy_consensus::BlockHeader as AlloyBlockHeader;
+
+/// Trait for accessing the timestamp from next block environment attributes.
+///
+/// This enables default implementations in [`ConfigureEvm`] that automatically
+/// apply EVM limits based on the timestamp.
+pub trait NextBlockTimestamp {
+    /// Returns the timestamp of the next block.
+    fn timestamp(&self) -> u64;
+}
+
+impl NextBlockTimestamp for NextBlockEnvAttributes {
+    fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}
 
 /// A complete configuration of EVM for Reth.
 ///
@@ -191,7 +208,9 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// Context required for configuring next block environment.
     ///
     /// Contains values that can't be derived from the parent block.
-    type NextBlockEnvCtx: Debug + Clone;
+    /// Must implement [`NextBlockTimestamp`] to enable default implementation
+    /// of [`Self::next_evm_env`] that automatically applies EVM limits.
+    type NextBlockEnvCtx: Debug + Clone + NextBlockTimestamp;
 
     /// Configured [`BlockExecutorFactory`], contains [`EvmFactory`] internally.
     type BlockExecutorFactory: for<'a> BlockExecutorFactory<
@@ -218,14 +237,53 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// Returns reference to the configured [`BlockAssembler`].
     fn block_assembler(&self) -> &Self::BlockAssembler;
 
-    /// Creates a new [`EvmEnv`] for the given header.
-    fn evm_env(&self, header: &HeaderTy<Self::Primitives>) -> Result<EvmEnvFor<Self>, Self::Error>;
+    /// Returns the EVM limit parameters for the given timestamp.
+    ///
+    /// This includes max code size, max initcode size, and transaction gas limit cap.
+    /// This is the single source of truth for EVM limits, ensuring consistency
+    /// between mempool validation and EVM execution.
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams;
 
-    /// Returns the configured [`EvmEnv`] for `parent + 1` block.
+    /// Creates a new [`EvmEnv`] for the given header without applying EVM limits.
+    ///
+    /// Implementors should return the base EVM environment. The [`Self::evm_env`] method
+    /// will automatically apply limits from [`Self::evm_limit_params_at_timestamp`].
+    fn evm_env_without_limits(
+        &self,
+        header: &HeaderTy<Self::Primitives>,
+    ) -> Result<EvmEnvFor<Self>, Self::Error>;
+
+    /// Creates a new [`EvmEnv`] for the given header with EVM limits applied.
+    ///
+    /// This is the public interface that should be used by callers. It internally calls
+    /// [`Self::evm_env_without_limits`] and applies limits from
+    /// [`Self::evm_limit_params_at_timestamp`].
+    fn evm_env(&self, header: &HeaderTy<Self::Primitives>) -> Result<EvmEnvFor<Self>, Self::Error>
+    where
+        HeaderTy<Self::Primitives>: AlloyBlockHeader,
+    {
+        self.evm_env_without_limits(header)
+            .map(|env| env.with_limits(self.evm_limit_params_at_timestamp(header.timestamp())))
+    }
+
+    /// Returns the configured [`EvmEnv`] for `parent + 1` block without applying EVM limits.
+    ///
+    /// Implementors should return the base EVM environment. The [`Self::next_evm_env`] method
+    /// will automatically apply limits from [`Self::evm_limit_params_at_timestamp`].
+    fn next_evm_env_without_limits(
+        &self,
+        parent: &HeaderTy<Self::Primitives>,
+        attributes: &Self::NextBlockEnvCtx,
+    ) -> Result<EvmEnvFor<Self>, Self::Error>;
+
+    /// Returns the configured [`EvmEnv`] for `parent + 1` block with EVM limits applied.
     ///
     /// This is intended for usage in block building after the merge and requires additional
     /// attributes that can't be derived from the parent block: attributes that are determined by
     /// the CL, such as the timestamp, suggested fee recipient, and randomness value.
+    ///
+    /// The default implementation calls [`Self::next_evm_env_without_limits`] and applies EVM
+    /// limits from [`Self::evm_limit_params_at_timestamp`].
     ///
     /// # Example
     ///
@@ -235,12 +293,16 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// // - Correct spec ID based on timestamp and block number
     /// // - Block environment with next block's parameters
     /// // - Configuration like chain ID and blob parameters
+    /// // - EVM limits (max code size, initcode size, tx gas limit cap)
     /// ```
     fn next_evm_env(
         &self,
         parent: &HeaderTy<Self::Primitives>,
         attributes: &Self::NextBlockEnvCtx,
-    ) -> Result<EvmEnvFor<Self>, Self::Error>;
+    ) -> Result<EvmEnvFor<Self>, Self::Error> {
+        self.next_evm_env_without_limits(parent, attributes)
+            .map(|env| env.with_limits(self.evm_limit_params_at_timestamp(attributes.timestamp())))
+    }
 
     /// Returns the configured [`BlockExecutorFactory::ExecutionCtx`] for a given block.
     fn context_for_block<'a>(

--- a/crates/evm/evm/src/noop.rs
+++ b/crates/evm/evm/src/noop.rs
@@ -1,6 +1,6 @@
 //! Helpers for testing.
 
-use crate::{ConfigureEvm, EvmEnvFor};
+use crate::{ConfigureEvm, EvmEnvFor, EvmLimitParams};
 use reth_primitives_traits::{BlockTy, HeaderTy, SealedBlock, SealedHeader};
 
 /// A no-op EVM config that panics on any call. Used as a typesystem hack to satisfy
@@ -43,16 +43,23 @@ where
         self.inner().block_assembler()
     }
 
-    fn evm_env(&self, header: &HeaderTy<Self::Primitives>) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.inner().evm_env(header)
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.inner().evm_limit_params_at_timestamp(timestamp)
     }
 
-    fn next_evm_env(
+    fn evm_env_without_limits(
+        &self,
+        header: &HeaderTy<Self::Primitives>,
+    ) -> Result<EvmEnvFor<Self>, Self::Error> {
+        self.inner().evm_env_without_limits(header)
+    }
+
+    fn next_evm_env_without_limits(
         &self,
         parent: &HeaderTy<Self::Primitives>,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.inner().next_evm_env(parent, attributes)
+        self.inner().next_evm_env_without_limits(parent, attributes)
     }
 
     fn context_for_block<'a>(

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -2,6 +2,7 @@ pub use alloy_op_evm::{
     spec as revm_spec, spec_by_timestamp_after_bedrock as revm_spec_by_timestamp_after_bedrock,
 };
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
+use reth_evm::NextBlockTimestamp;
 use revm::primitives::{Address, Bytes, B256};
 
 /// Context relevant for execution of a next block w.r.t OP.
@@ -47,5 +48,11 @@ impl From<OpFlashblockPayloadBase> for OpNextBlockEnvAttributes {
             parent_beacon_block_root: Some(base.parent_beacon_block_root),
             extra_data: base.extra_data,
         }
+    }
+}
+
+impl NextBlockTimestamp for OpNextBlockEnvAttributes {
+    fn timestamp(&self) -> u64 {
+        self.timestamp
     }
 }

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -20,7 +20,8 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_revm::{OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
-    eth::NextEvmEnvAttributes, precompiles::PrecompilesMap, ConfigureEvm, EvmEnv, TransactionEnv,
+    eth::NextEvmEnvAttributes, precompiles::PrecompilesMap, ConfigureEvm, EvmEnv, EvmLimitParams,
+    TransactionEnv,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
@@ -159,12 +160,15 @@ where
         &self.block_assembler
     }
 
-    fn evm_env(&self, header: &Header) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(EvmEnv::for_op_block(header, self.chain_spec(), self.chain_spec().chain().id())
-            .with_limits(self.chain_spec().evm_limit_params_at_timestamp(header.timestamp())))
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.chain_spec().evm_limit_params_at_timestamp(timestamp)
     }
 
-    fn next_evm_env(
+    fn evm_env_without_limits(&self, header: &Header) -> Result<EvmEnv<OpSpecId>, Self::Error> {
+        Ok(EvmEnv::for_op_block(header, self.chain_spec(), self.chain_spec().chain().id()))
+    }
+
+    fn next_evm_env_without_limits(
         &self,
         parent: &Header,
         attributes: &Self::NextBlockEnvCtx,
@@ -180,8 +184,7 @@ where
             self.chain_spec().next_block_base_fee(parent, attributes.timestamp).unwrap_or_default(),
             self.chain_spec(),
             self.chain_spec().chain().id(),
-        )
-        .with_limits(self.chain_spec().evm_limit_params_at_timestamp(attributes.timestamp)))
+        ))
     }
 
     fn context_for_block(
@@ -258,8 +261,7 @@ where
             blob_excess_gas_and_price,
         };
 
-        Ok(EvmEnv { cfg_env, block_env }
-            .with_limits(self.chain_spec().evm_limit_params_at_timestamp(timestamp)))
+        Ok(EvmEnv { cfg_env, block_env }.with_limits(self.evm_limit_params_at_timestamp(timestamp)))
     }
 
     fn context_for_payload<'a>(

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -19,7 +19,7 @@ use reth_ethereum::{
     evm::{
         primitives::{
             execute::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
-            Database, Evm, EvmEnv, EvmEnvFor, ExecutionCtxFor, InspectorFor,
+            Database, Evm, EvmEnv, EvmEnvFor, EvmLimitParams, ExecutionCtxFor, InspectorFor,
             NextBlockEnvAttributes, OnStateHook,
         },
         revm::{
@@ -135,16 +135,20 @@ impl ConfigureEvm for CustomEvmConfig {
         self.inner.block_assembler()
     }
 
-    fn evm_env(&self, header: &Header) -> Result<EvmEnv<SpecId>, Self::Error> {
-        self.inner.evm_env(header)
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.inner.evm_limit_params_at_timestamp(timestamp)
     }
 
-    fn next_evm_env(
+    fn evm_env_without_limits(&self, header: &Header) -> Result<EvmEnv<SpecId>, Self::Error> {
+        self.inner.evm_env_without_limits(header)
+    }
+
+    fn next_evm_env_without_limits(
         &self,
         parent: &Header,
         attributes: &NextBlockEnvAttributes,
     ) -> Result<EvmEnv<SpecId>, Self::Error> {
-        self.inner.next_evm_env(parent, attributes)
+        self.inner.next_evm_env_without_limits(parent, attributes)
     }
 
     fn context_for_block<'a>(

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -20,7 +20,7 @@ use reth_ethereum::{
 use reth_node_builder::{ConfigureEngineEvm, NewPayloadError};
 use reth_op::{
     chainspec::OpHardforks,
-    evm::primitives::{EvmEnvFor, ExecutionCtxFor},
+    evm::primitives::{EvmEnvFor, EvmLimitParams, ExecutionCtxFor, NextBlockTimestamp},
     node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
     primitives::SignedTransaction,
 };
@@ -63,16 +63,23 @@ impl ConfigureEvm for CustomEvmConfig {
         &self.block_assembler
     }
 
-    fn evm_env(&self, header: &CustomHeader) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        self.inner.evm_env(header)
+    fn evm_limit_params_at_timestamp(&self, timestamp: u64) -> EvmLimitParams {
+        self.inner.evm_limit_params_at_timestamp(timestamp)
     }
 
-    fn next_evm_env(
+    fn evm_env_without_limits(
+        &self,
+        header: &CustomHeader,
+    ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
+        self.inner.evm_env_without_limits(header)
+    }
+
+    fn next_evm_env_without_limits(
         &self,
         parent: &CustomHeader,
         attributes: &CustomNextBlockEnvAttributes,
     ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        self.inner.next_evm_env(parent, &attributes.inner)
+        self.inner.next_evm_env_without_limits(parent, &attributes.inner)
     }
 
     fn context_for_block(
@@ -149,6 +156,12 @@ pub struct CustomNextBlockEnvAttributes {
 impl From<OpFlashblockPayloadBase> for CustomNextBlockEnvAttributes {
     fn from(value: OpFlashblockPayloadBase) -> Self {
         Self { inner: value.into(), extension: 0 }
+    }
+}
+
+impl NextBlockTimestamp for CustomNextBlockEnvAttributes {
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp
     }
 }
 


### PR DESCRIPTION
## Summary

Refactors `ConfigureEvm` to enforce that EVM limits are always applied, eliminating the risk of SDK users forgetting to call `.with_limits()` in their custom implementations.

**Problem**: Previously, implementors of `ConfigureEvm` had to manually call `.with_limits()` in both `evm_env()` and `next_evm_env()`. This made it easy to forget to apply limits.

**Solution**: Introduces a template method pattern:
- Adds `evm_env_without_limits()` and `next_evm_env_without_limits()` as required methods that return the base environment
- `evm_env()` and `next_evm_env()` now have default implementations that automatically apply limits
- Adds `evm_limit_params_at_timestamp()` as a required method to provide limits
- Introduces `NextBlockTimestamp` trait to enable accessing timestamp from `NextBlockEnvCtx`

**NOTE: This impl is missing equivalent for ConfigureEngineEvm**
