### PR TITLE
fix(txpool): keep PendingPool sender caches in sync with by_id

### DIFF
--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -311,22 +311,46 @@ impl<T: TransactionOrdering> PendingPool<T> {
     ///
     /// Note: If the transaction has a descendant transaction
     /// it will advance it to the best queue.
+    ///
+    /// Sender-level caches (`independent_transactions` and `highest_nonces`) are
+    /// recomputed from `by_id` after a successful removal, so that these caches
+    /// stay consistent with `by_id` even if the caller passes an id that is the
+    /// not the sender's cached lowest/highest. This is important because callers
+    /// (e.g. `TxPool::remove_from_subpool`) may invoke this method with an id that
+    /// is anywhere in the sender's nonce range, and we must never let the cached
+    /// `independent_transactions` entry drift away from `by_id`'s actual lowest.
     pub(crate) fn remove_transaction(
         &mut self,
         id: &TransactionId,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        // Remove from `by_id` first. If the tx is not actually tracked by this
+        // subpool (e.g. caller passed a stale id), don't mutate sender-level
+        // indexes. Mutating them before confirming removal would leave the
+        // sender's cached lowest/highest pointing at something inconsistent with
+        // `by_id`, which corrupts `best()` iterators (see
+        // `independent_transactions` use in `PendingPool::best`).
+        let tx = self.by_id.remove(id)?;
+        self.size_of -= tx.transaction.size();
+
+        // If we removed the cached lowest, advance to the new lowest by scanning
+        // `by_id` forward from this sender. Using `by_id` directly (rather than
+        // `get(&id.descendant())`) preserves correctness even when there is a
+        // gap in the sender's pending nonces.
         if let Some(lowest) = self.independent_transactions.get(&id.sender) &&
             lowest.transaction.nonce() == id.nonce
         {
             self.independent_transactions.remove(&id.sender);
-            // mark the next as independent if it exists
-            if let Some(unlocked) = self.get(&id.descendant()) {
-                self.independent_transactions.insert(id.sender, unlocked.clone());
+            if let Some((_, new_lowest)) = self
+                .by_id
+                .range((
+                    id.sender.start_bound(),
+                    std::ops::Bound::Included(TransactionId::new(id.sender, u64::MAX)),
+                ))
+                .next()
+            {
+                self.independent_transactions.insert(id.sender, new_lowest.clone());
             }
         }
-
-        let tx = self.by_id.remove(id)?;
-        self.size_of -= tx.transaction.size();
 
         match self.highest_nonces.entry(id.sender) {
             Entry::Occupied(mut entry) => {
@@ -601,6 +625,43 @@ impl<T: TransactionOrdering> PendingPool<T> {
             self.independent_transactions.len(),
             "highest_nonces.len() != independent_transactions.len()"
         );
+
+        // Per-sender bounds must match `by_id`: the cached independent entry
+        // must be the sender's lowest nonce in `by_id`, and the cached highest
+        // entry must be the sender's highest nonce in `by_id`. Drift here is
+        // what causes `best()` to start iteration from the wrong nonce.
+        for (sender, lowest) in &self.independent_transactions {
+            let actual_lowest = self
+                .by_id
+                .range((
+                    sender.start_bound(),
+                    std::ops::Bound::Included(TransactionId::new(*sender, u64::MAX)),
+                ))
+                .next()
+                .map(|(id, _)| id.nonce);
+            assert_eq!(
+                Some(lowest.transaction.nonce()),
+                actual_lowest,
+                "independent_transactions[{:?}] is out of sync with by_id",
+                sender,
+            );
+        }
+        for (sender, highest) in &self.highest_nonces {
+            let actual_highest = self
+                .by_id
+                .range((
+                    sender.start_bound(),
+                    std::ops::Bound::Included(TransactionId::new(*sender, u64::MAX)),
+                ))
+                .next_back()
+                .map(|(id, _)| id.nonce);
+            assert_eq!(
+                Some(highest.transaction.nonce()),
+                actual_highest,
+                "highest_nonces[{:?}] is out of sync with by_id",
+                sender,
+            );
+        }
     }
 }
 
@@ -1129,6 +1190,91 @@ mod tests {
         let id0 = TransactionId::new(sender_id, 0);
         let _ = pool.remove_transaction(&id0);
         assert!(!pool.highest_nonces.contains_key(&sender_id));
+        pool.assert_invariants();
+    }
+
+    /// Removing a tx whose id is not present in `by_id` must not mutate the
+    /// sender-level caches. Without the fix in `remove_transaction`,
+    /// `independent_transactions` was advanced (or cleared) even when the
+    /// underlying `by_id.remove` returned `None`, leaving the cache pointing
+    /// at a transaction that no longer existed in the pool.
+    #[test]
+    fn test_remove_transaction_for_missing_id_is_noop() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let sender = address!("0x00000000000000000000000000000000000000dd");
+        let txs = MockTransactionSet::dependent(sender, 0, 3, TxType::Eip1559).into_vec();
+        for tx in txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+        pool.assert_invariants();
+
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let id0 = TransactionId::new(sender_id, 0);
+        let cached_lowest_before =
+            pool.independent_transactions.get(&sender_id).map(|tx| tx.transaction.nonce());
+        let cached_highest_before =
+            pool.highest_nonces.get(&sender_id).map(|tx| tx.transaction.nonce());
+
+        // Simulate a stale subpool/all_transactions divergence: pretend the tx
+        // was removed from `by_id` by some other path. The caller can still
+        // invoke `remove_transaction` with the stale id (e.g. through
+        // `TxPool::remove_from_subpool` after an inconsistency).
+        pool.by_id.remove(&id0).expect("nonce 0 must be in by_id");
+
+        // remove_transaction must report "not found" and must not mutate
+        // sender-level caches.
+        assert!(pool.remove_transaction(&id0).is_none());
+        let cached_lowest_after =
+            pool.independent_transactions.get(&sender_id).map(|tx| tx.transaction.nonce());
+        let cached_highest_after =
+            pool.highest_nonces.get(&sender_id).map(|tx| tx.transaction.nonce());
+
+        assert_eq!(cached_lowest_before, cached_lowest_after);
+        assert_eq!(cached_highest_before, cached_highest_after);
+    }
+
+    /// `remove_transaction` must keep `independent_transactions` consistent
+    /// with `by_id` even when there is a non-contiguous nonce range, by
+    /// scanning `by_id` for the actual next lowest rather than relying on
+    /// `get(id.descendant())`.
+    #[test]
+    fn test_remove_lowest_advances_independent_across_gap() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let sender = address!("0x00000000000000000000000000000000000000ee");
+
+        // Build a sender chain [0, 1, 3] (i.e. nonce 2 is missing from `by_id`).
+        let mut txs = MockTransactionSet::dependent(sender, 0, 4, TxType::Eip1559).into_vec();
+        // Remove nonce 2 from the slice before insertion.
+        let removed = txs.remove(2);
+        assert_eq!(removed.nonce(), 2);
+        for tx in &txs {
+            pool.add_transaction(f.validated_arc(tx.clone()), 0);
+        }
+        pool.assert_invariants();
+
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let id0 = TransactionId::new(sender_id, 0);
+
+        // After removing nonce 0, the cached lowest must advance to nonce 1
+        // (which is still present), not to nonce 2 (the descendant, which is
+        // absent from `by_id`).
+        let removed_tx = pool.remove_transaction(&id0).expect("nonce 0 was in pool");
+        assert_eq!(removed_tx.nonce(), 0);
+        let new_lowest =
+            pool.independent_transactions.get(&sender_id).expect("sender still has pending txs");
+        assert_eq!(new_lowest.transaction.nonce(), 1);
+        pool.assert_invariants();
+
+        // After removing nonce 1, the cached lowest must skip the gap at 2
+        // and advance to nonce 3.
+        let id1 = TransactionId::new(sender_id, 1);
+        let removed_tx = pool.remove_transaction(&id1).expect("nonce 1 was in pool");
+        assert_eq!(removed_tx.nonce(), 1);
+        let new_lowest =
+            pool.independent_transactions.get(&sender_id).expect("sender still has pending txs");
+        assert_eq!(new_lowest.transaction.nonce(), 3);
         pool.assert_invariants();
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -4790,4 +4790,107 @@ mod tests {
         assert_eq!(t2.id().nonce, 2, "expected nonce 2, got {}", t2.id().nonce);
         assert_eq!(t3.id().nonce, 3, "expected nonce 3, got {}", t3.id().nonce);
     }
+
+    /// Regression test: a prune-induced gap in `pending_pool.by_id` must not
+    /// corrupt the sender's cached lowest-pending-nonce, which
+    /// `best_transactions_with_attributes` uses to seed its iterator.
+    ///
+    /// Production failure mode observed on the conduit-rust flashblocks
+    /// builder: the builder prunes transactions out of order across flashblocks
+    /// in the same block. When the immediate descendant of a "lowest" pending
+    /// tx had already been pruned earlier, the pre-fix
+    /// `PendingPool::remove_transaction` advanced `independent_transactions`
+    /// via `get(&id.descendant())`, which silently returned `None` across the
+    /// prune-induced gap and CLEARED the cache, even though the sender still
+    /// had pending transactions at higher nonces.
+    ///
+    /// With the cache cleared, `pending_pool.best()` seeded
+    /// `BestTransactions.independent` from an empty set for that sender, so
+    /// every subsequent `best_transactions_with_attributes(..).next()` yielded
+    /// nothing for the sender (or, in deeper-churn variants of the same root
+    /// cause, yielded a nonce far above the on-chain nonce that the EVM then
+    /// rejected as `nonce too high`).
+    ///
+    /// This test drives the failure end-to-end through `TxPool`'s public API
+    /// (`add_transaction`, `prune_transactions`,
+    /// `best_transactions_with_attributes`) and asserts on the observable
+    /// behaviour of the best-transactions iterator.
+    #[test]
+    fn test_best_transactions_recovers_after_prune_induced_gap() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // 5 consecutive pending txs from a single sender, all funded.
+        let sender = address!("0x000000000000000000000000000000000000beef");
+        let txs = MockTransactionSet::dependent(sender, 0, 5, TxType::Eip1559)
+            .into_vec()
+            .into_iter()
+            .map(|tx| tx.inc_price().inc_limit())
+            .collect::<Vec<_>>();
+        let hashes: Vec<_> = txs
+            .iter()
+            .map(|tx| {
+                let validated = f.validated(tx.clone());
+                let hash = *validated.hash();
+                pool.add_transaction(validated, U256::MAX, 0, None).unwrap();
+                hash
+            })
+            .collect();
+
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        assert_eq!(pool.pending_pool.len(), 5, "all 5 txs should be in pending");
+        assert_eq!(
+            pool.pending_pool.independent().get(&sender_id).map(|tx| tx.transaction.nonce()),
+            Some(0),
+            "cached lowest pending nonce should be 0 before any prunes",
+        );
+
+        // Prune the mid-chain tx at nonce 1. `prune_transactions` removes the
+        // tx from `all_transactions` and from its subpool without parking
+        // descendants, so nonces 2..=4 stay in `pending_pool.by_id`. This
+        // leaves a gap in `by_id` at nonce 1, even though the cached lowest
+        // (nonce 0) is unaffected.
+        let pruned_mid = pool.prune_transactions(vec![hashes[1]]);
+        assert_eq!(pruned_mid.len(), 1, "nonce 1 must be pruned");
+        assert_eq!(pool.pending_pool.len(), 4);
+
+        // Now prune the tx at nonce 0 (the cached lowest). This drives
+        // `PendingPool::remove_transaction(&id0)` with `cache.lowest == id0`.
+        // Pre-fix, the cache advanced via `get(id0.descendant())`, which looks
+        // up id1 — but id1 was pruned in the previous step, so the lookup
+        // returned `None` and the cache was cleared entirely. With the fix,
+        // the cache is recomputed via a `by_id` range scan and correctly
+        // advances to id2.
+        let pruned_lowest = pool.prune_transactions(vec![hashes[0]]);
+        assert_eq!(pruned_lowest.len(), 1, "nonce 0 must be pruned");
+        assert_eq!(pool.pending_pool.len(), 3);
+
+        // The cached lowest must point at nonce 2 (the actual lowest still in
+        // `pending_pool.by_id`). Pre-fix this assertion fails — the cache is
+        // empty for this sender.
+        let cached_lowest =
+            pool.pending_pool.independent().get(&sender_id).map(|tx| tx.transaction.nonce());
+        assert_eq!(
+            cached_lowest,
+            Some(2),
+            "independent_transactions cache must advance past the prune-induced gap",
+        );
+
+        // End-to-end: `best_transactions_with_attributes` seeds its iterator
+        // from the per-sender cached lowest. Pre-fix, this yields nothing for
+        // this sender even though `by_id` still has nonces 2..=4, and the
+        // builder produces an empty block.
+        let attrs = BestTransactionsAttributes::base_fee(pool.block_info().pending_basefee);
+        let next = pool
+            .best_transactions_with_attributes(attrs)
+            .next()
+            .expect("pending pool still has 3 txs for this sender; best should yield one");
+        assert_eq!(
+            next.id().nonce,
+            2,
+            "best_transactions must yield the lowest pending nonce still in by_id",
+        );
+
+        pool.assert_invariants();
+    }
 }


### PR DESCRIPTION
## Summary

`PendingPool::remove_transaction` mutated the sender's cached `independent_transactions` entry BEFORE confirming the tx still lived in `by_id`. Any call to `pending_pool.remove_transaction(id)` for an id missing from `by_id` (for example through `TxPool::remove_from_subpool` after an `all_transactions` <-> subpool divergence) ratcheted the cache without removing anything. The cache then pointed at a non-minimum nonce for that sender, and because `PendingPool::best` seeds the iterator's `independent` set from `self.independent_transactions.values()`, every fresh `best_transactions_with_attributes` snapshot started iteration from the wrong nonce for that sender. EVM rejects each yielded tx with `nonce too high`, the iterator marks the sender invalid, nothing is applied, the next iterator recreates the same broken snapshot, and the sender effectively gets stuck.

The same shape of divergence is also reachable through `TxPool`'s public API: `prune_transactions` removes a tx from both `all_transactions` and its subpool WITHOUT parking descendants, so it can leave gaps in `pending_pool.by_id`. The pre-fix `remove_transaction` advanced the cached lowest via `get(&id.descendant())`, which silently returns `None` across such a gap and CLEARED the cache, even though the sender still had pending transactions at higher nonces.

`update_accounts` cannot heal this state: `AllTransactions::update` only emits `PoolUpdate`s when a tx's subpool changes, so a sender whose chain stays fully in `Pending` never gets its `independent_transactions` entry touched.

## Operational observation and validation

We first noticed this as a live txpool / payload-builder symptom rather than as a unit-test failure. Under high-throughput payload-building load, one sender maintained a large contiguous pending range (~20k transactions). `txpool_status` reported a full pending pool, `txpool_content` showed contiguous sender nonces from the chain nonce through the pending nonce, and `eth_getTransactionCount(..., "latest")` matched the lowest pending nonce. Despite that, fresh `best_transactions_with_attributes` snapshots repeatedly started from a much higher sender nonce. The EVM rejected that yielded transaction with `nonce too high`; after the iterator marked the sender invalid, no transaction from that sender was applied. Recreating the iterator reproduced the same wrong first transaction because the stale sender cache remained the seed for `PendingPool::best`.

We tested the fix in two ways:

1. Added focused txpool regressions that fail on the unfixed code and pass with this patch:
   - missing-id removal must not mutate sender caches;
   - removing the cached lowest tx must recompute the next lowest from `by_id`, including across nonce gaps;
   - the public `TxPool` API must recover after `prune_transactions` creates a pending nonce gap.
2. Backported the exact txpool change onto a reth v2.2.0-based deployment and reran the same high-throughput load. After rollout, the txpool stayed populated and the sender nonce range kept advancing; the permanent `nonce too high` / no-progress loop disappeared. We still observed occasional low-transaction blocks during stress, but those correlated with payload build time exceeding the block cadence while the txpool remained populated and the latest/pending nonce range continued advancing. That points to a separate payload-building throughput/cadence issue, not this sender-cache desynchronization.

## Fix

`crates/transaction-pool/src/pool/pending.rs`:

- Move `let tx = self.by_id.remove(id)?;` to the top of `remove_transaction`. Sender-level caches are only mutated after a successful removal, so a stale id can no longer corrupt them.
- When the cached lowest is removed, advance to the new lowest by scanning `by_id` forward for the sender (range query) instead of looking up `id.descendant()`, so a gap in the sender's pending nonces does not silently break the cache.
- Strengthen `assert_invariants` to verify, per sender, that `independent_transactions` equals `min(by_id[sender])` and `highest_nonces` equals `max(by_id[sender])`. This catches drift immediately in tests.

## Tests

Three regression tests, all of which fail against the unfixed code and pass against the fix:

- `pool::pending::tests::test_remove_transaction_for_missing_id_is_noop` (private-state, exercises the divergence directly on `PendingPool`).
- `pool::pending::tests::test_remove_lowest_advances_independent_across_gap` (private-state, asserts the cache crosses a synthetic gap).
- `pool::txpool::tests::test_best_transactions_recovers_after_prune_induced_gap` (end-to-end through `TxPool`'s public API: `add_transaction`, `prune_transactions`, `best_transactions_with_attributes`).

### Before / After for the public-API test

Reverting just the `pending.rs::remove_transaction` change (leaving the new test applied) and running the public-API test reproduces the production failure mode:

```
$ cargo test -p reth-transaction-pool --lib \
    test_best_transactions_recovers_after_prune_induced_gap

running 1 test

thread 'pool::txpool::tests::test_best_transactions_recovers_after_prune_induced_gap'
  panicked at crates/transaction-pool/src/pool/txpool.rs:4876:9:
assertion `left == right` failed: independent_transactions cache must
advance past the prune-induced gap
  left: None
 right: Some(2)
```

With the fix re-applied:

```
$ cargo test -p reth-transaction-pool --lib \
    test_best_transactions_recovers_after_prune_induced_gap

running 1 test
test pool::txpool::tests::test_best_transactions_recovers_after_prune_induced_gap ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 241 filtered out
```

## Verification

`cargo test -p reth-transaction-pool --lib` — all 242 tests pass, including the 3 new ones. `cargo +nightly fmt --all --check` and `cargo +nightly clippy -p reth-transaction-pool --lib --tests --all-features` are clean.

